### PR TITLE
Detect broken RSA keys returned from Travis API

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -19,11 +19,15 @@ $("#encrypt").bind("click", function() {
     if(result.key) {
       crypt = new JSEncrypt();
       crypt.setPublicKey(result.key);
-      secure = crypt.encrypt(value);
-      pre    = $("<pre></pre>")
-      pre.text('secure: ' + secure + '');
-      say('<p>Place the following in your <em>.travis.yml</em> instead of the unencrypted value:</p>');
-      output.append(pre);
+      if(!crypt.key.n) {
+        error("Broken RSA key from Travis API");
+      } else {
+        secure = crypt.encrypt(value);
+        pre    = $("<pre></pre>")
+        pre.text('secure: ' + secure);
+        say('<p>Place the following in your <em>.travis.yml</em> instead of the unencrypted value:</p>');
+        output.append(pre);
+      }
     } else {
       error("Broken payload from Travis API");
     }


### PR DESCRIPTION
Now script will detect not initialized key (as returned for sinatra/sinatra repo #1, same as in travis-ci/travis-ci#913) before trying to encrypt text. You can see [fix in action](https://slodki.github.io/travis-encrypt/public/index.html).